### PR TITLE
when scrolling, only invert the vertical delta

### DIFF
--- a/packages/Sandblocks-Core/SBEditorCanvas.class.st
+++ b/packages/Sandblocks-Core/SBEditorCanvas.class.st
@@ -153,7 +153,7 @@ SBEditorCanvas >> mouseWheel: anEvent [
 
 	(anEvent commandKeyPressed and: [dragStartPosition notNil])
 		ifTrue: [self zoomViewport: anEvent wheelDelta y from: dragStartPosition]
-		ifFalse: [self viewportPosition: targetPosition + anEvent wheelDelta negated]
+		ifFalse: [self viewportPosition: targetPosition + (anEvent wheelDelta * (1@(-1)))]
 ]
 
 { #category : #viewport }


### PR DESCRIPTION
on macos, the horizontal scrolling of the sbeditor is the wrong way around.

I assume, this is the same on other platforms, but was not used

In that case, this is the fix for it…