### PR TITLE
Fix usage of `#inheritsFrom:`

### DIFF
--- a/packages/Sandblocks-Smalltalk/SBStBasicMethod.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStBasicMethod.class.st
@@ -693,7 +693,7 @@ SBStBasicMethod >> toggleCollapsed [
 { #category : #'as yet unclassified' }
 SBStBasicMethod >> tryUseAsSelf: anObject [
 
-	(anObject class = self relatedClass or: [anObject class inheritsFrom: self relatedClass]) ifTrue: [
+	(anObject class includesBehavior: self relatedClass) ifTrue: [
 		self setProperty: #evaluationReceiver toValue: anObject.
 		
 		(Array streamContents: [:str | self allBlocksDo: [:block | (SBSelfThumbnailRepresentation matches: block) ifTrue: [str nextPut: block]]]) ifNotEmpty: [:selfs |

--- a/packages/Sandblocks-Smalltalk/SBStClass.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStClass.class.st
@@ -171,11 +171,15 @@ SBStClass >> example [
 ]
 
 { #category : #'class protocol' }
+SBStClass >> includesBehavior: aClass [
+
+	^ self relatedClass = aClass or: [self inheritsFrom: aClass]
+]
+
+{ #category : #'class protocol' }
 SBStClass >> inheritsFrom: aClass [
 
-	| superclass |
-	superclass := Smalltalk at: self superClassName asSymbol.
-	^ superclass = aClass or: [superclass inheritsFrom: aClass]
+	^ self superclass = aClass or: [self superclass inheritsFrom: aClass]
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Smalltalk/SBStMorphPalette.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStMorphPalette.class.st
@@ -56,7 +56,7 @@ SBStMorphPalette class >> buildOn: aContainer [
 { #category : #'as yet unclassified' }
 SBStMorphPalette class >> context [
 
-	^ {#isSmalltalk. [:block | block containingArtefact satisfies: {#notNil. #isMethod. [:a | a relatedClass inheritsFrom: Morph]}]}
+	^ {#isSmalltalk. [:block | block containingArtefact satisfies: {#notNil. #isMethod. [:a | a relatedClass includesBehavior: Morph]}]}
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
Show the Morph palette for methods located in the Morph class itself, too, as opposed to its super+classes only. Implement `#includesBehavior:` on `SBStClass` next to `#inheritsFrom:`, just in case. Minor refactoring.