### PR TITLE
Elaborate Ohm dependency in baseline

### DIFF
--- a/packages/BaselineOfSandblocks/BaselineOfSandblocks.class.st
+++ b/packages/BaselineOfSandblocks/BaselineOfSandblocks.class.st
@@ -49,7 +49,7 @@ BaselineOfSandblocks >> baseline: spec [
 				with: [spec repository: 'github://active-expressions/active-expressions-squeak:master/src'];
 			baseline: 'RatPack' with: [spec repository: 'github://hpi-swa-teaching/RatPack:develop/packages'];
 			baseline: 'QoppaS' with: [spec repository: 'github://hpi-swa-lab/QoppaS/packages'];
-			baseline: 'Ohm' with: [spec repository: 'github://hpi-swa/ohm-s/packages'];
+			baseline: 'Ohm' with: [spec repository: 'github://hpi-swa/Ohm-S:master/packages'];
 			package: 'SVG-Morphic' with: [spec repository: 'http://www.squeaksource.com/SVGMorph'];
 			package: 'PoppyPrint-Core' with: [spec repository: 'github://tom95/poppy-print/packages'].
 


### PR DESCRIPTION
Spell out the repository path to make it compatible with other references, e.g., https://github.com/hpi-swa-lab/babylonian-programming-smalltalk/blob/e72647f9d397ab49dcd1f14e9814a513e5fa5ad3/packages/BaselineOfBabylonianProgramming.package/BaselineOfBabylonianProgramming.class/instance/baseline..st#L10. See also https://github.com/Metacello/metacello/pull/542.