### PR TITLE
core: add hook `#markSaved:` to `SBEditor`

### DIFF
--- a/packages/Sandblocks-Core/SBEditor.class.st
+++ b/packages/Sandblocks-Core/SBEditor.class.st
@@ -873,16 +873,22 @@ SBEditor >> loadBlocks [
 
 { #category : #'do/undo/redo' }
 SBEditor >> markChangesAfterCommand: artefacts [
-
+	 
 	artefacts do: [:candidate | | artefact |
 		artefact := candidate canPersist
 			ifTrue: [candidate]
 			ifFalse: [candidate artefactForPersisting ifNil: [candidate]].
 		
-		(self compileTime = #compileOnChange and: [self save: artefact tryFixing: false quick: false]) ifTrue: [history markSaved: true].
+		(self compileTime = #compileOnChange and: [self save: artefact tryFixing: false quick: false]) ifTrue: [self markSaved: true].
 		
 		artefact triggerEvent: #changed.
 		self allBlocksDo: [:block | block artefactChanged: artefact]]
+]
+
+{ #category : #'as yet unclassified' }
+SBEditor >> markSaved: anArtefact [
+
+	^ history markSaved: anArtefact
 ]
 
 { #category : #accessing }
@@ -1285,10 +1291,10 @@ SBEditor >> save [
 
 { #category : #artefacts }
 SBEditor >> save: anArtefact tryFixing: aFixBoolean quick: aQuickBoolean [
-
+	 
 	^ (anArtefact saveTryFixing: aFixBoolean quick: aQuickBoolean)
 		ifTrue: [
-			history markSaved: anArtefact.
+			self markSaved: anArtefact.
 			self triggerEvent: #artefactSaved with: anArtefact.
 			self allBlocksDo: [:block | block artefactSaved: anArtefact].
 			true]


### PR DESCRIPTION
This will be [used](https://github.com/LinqLover/sonyx/blob/10b7cb4833f246534143c97e3162c0b8402ee44a/packages/Sonyx-UI.package/SonyxSandblocksContainer.class/instance/reloadArtefact.st) by Sonyx (sent from a subclass of `SBStContainer`).