### PR TITLE
:balloon: recategorize party :balloon:

### DIFF
--- a/packages/Sandblocks-Core/CodeHolder.extension.st
+++ b/packages/Sandblocks-Core/CodeHolder.extension.st
@@ -20,7 +20,7 @@ CodeHolder >> blockEditor [
 	^ self containingWindow valueOfProperty: #blockEditor
 ]
 
-{ #category : #'*Sandblocks-Core' }
+{ #category : #'*Sandblocks-Core-contents-override' }
 CodeHolder >> contentsSymbol [
 	"Answer a symbol indicating what kind of content should be shown for the method; for normal showing of source code, this symbol is #source.  A nil value in the contentsSymbol slot will be set to #source by this method"
 
@@ -60,7 +60,7 @@ CodeHolder >> installBlockEditor [
 		with: (self containingWindow valueOfProperty: #blockEditor)
 ]
 
-{ #category : #'*Sandblocks-Core' }
+{ #category : #'*Sandblocks-Core-diffs-override' }
 CodeHolder >> restoreTextualCodingPane [
 	"If the receiver is showing tiles, restore the textual coding pane"
 

--- a/packages/Sandblocks-Core/Morph.extension.st
+++ b/packages/Sandblocks-Core/Morph.extension.st
@@ -111,7 +111,7 @@ Morph >> cursorPositionsDo: aBlock [
 	self isSandblock ifTrue: [self insertCursorNear: nil before: false do: aBlock]
 ]
 
-{ #category : #'*Sandblocks-Core-override' }
+{ #category : #'*Sandblocks-Core-geometry-override' }
 Morph >> extent: aPoint [
 
 	(bounds extent closeTo: aPoint) ifTrue: [^ self].
@@ -357,7 +357,7 @@ Morph >> parentSandblock [
 	^ self owner ifNotNil: #containingSandblock
 ]
 
-{ #category : #'*Sandblocks-Core-override' }
+{ #category : #'*Sandblocks-Core-geometry-override' }
 Morph >> position: aPoint [ 
 	"Change the position of this morph, which is the top left corner of its bounds."
 	

--- a/packages/Sandblocks-Core/SBOffscreenBlockIndicator.class.st
+++ b/packages/Sandblocks-Core/SBOffscreenBlockIndicator.class.st
@@ -26,7 +26,7 @@ SBOffscreenBlockIndicator class >> newFor: aMorph [
 	 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'*Sandblocks-Core' }
 SBOffscreenBlockIndicator >> containingSandblock [
 
 	^ self
@@ -46,7 +46,7 @@ SBOffscreenBlockIndicator >> foregroundColor [
 		ifFalse: [self owner containingSandblock foregroundColor]) alpha: self class defaultOpacity
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'event handling' }
 SBOffscreenBlockIndicator >> handlesMouseDown: anEvent [
 
 	^ self visible
@@ -71,7 +71,7 @@ SBOffscreenBlockIndicator >> indicatorColor: aColor [
 	self labelMorph color: aColor
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 SBOffscreenBlockIndicator >> initialize [
 
 	super initialize.
@@ -128,20 +128,20 @@ SBOffscreenBlockIndicator >> lastPosition: anObject [
 	lastPosition := anObject.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'event handling' }
 SBOffscreenBlockIndicator >> mouseDown: anEvent [
 	
 	self target isSandblock ifTrue: [self sandblockEditor select: self target].
 	Project current addDeferredUIMessage: [self scroller scrollToCenter: self target]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'*Sandblocks-Core' }
 SBOffscreenBlockIndicator >> objectInterface [
 
 	^ SBInterfaces never
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'events-processing' }
 SBOffscreenBlockIndicator >> rejectsEvent: anEvent [
 
 	self visible ifFalse: [^ true].
@@ -184,7 +184,7 @@ SBOffscreenBlockIndicator >> specialDropCommand: aBlock [
 	^ nil
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'stepping and presenter' }
 SBOffscreenBlockIndicator >> step [
 
 	| viewCenter direction intersections viewRectangle position |
@@ -216,7 +216,7 @@ SBOffscreenBlockIndicator >> step [
 	self iconMorph rotationDegrees: direction degrees
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'stepping and presenter' }
 SBOffscreenBlockIndicator >> stepTime [
 
 	 ^ 10

--- a/packages/Sandblocks-Core/SBOffscreenBlockIndicator.extension.st
+++ b/packages/Sandblocks-Core/SBOffscreenBlockIndicator.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #SBOffscreenBlockIndicator }
+
+{ #category : #'*Sandblocks-Core' }
+SBOffscreenBlockIndicator >> containingSandblock [
+
+	^ self
+]
+
+{ #category : #'*Sandblocks-Core' }
+SBOffscreenBlockIndicator >> objectInterface [
+
+	^ SBInterfaces never
+]

--- a/packages/Sandblocks-Smalltalk/SBStContainer.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStContainer.class.st
@@ -178,7 +178,7 @@ SBStContainer >> relatedClass [
 	^ self methodClass
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'compilation cue protocol' }
 SBStContainer >> sandblockBlockColorIfAbsent: aBlock [
 
 	^ self preferredColor


### PR DESCRIPTION
most important: add `-override` suffix to extension methods that shadow existing methods from the base system, so that Monticello does not fall over them (e.g., if sandblocks should be ever unloaded, for instance during a squot operation)