### PR TITLE
Fix default window size

### DIFF
--- a/packages/Sandblocks-Core/SBEditor.class.st
+++ b/packages/Sandblocks-Core/SBEditor.class.st
@@ -1038,6 +1038,7 @@ SBEditor >> openInWindow [
 	window model: self.
 	
 	window := window openInWorldExtent: self extent.
+	window extent: self fullBounds extent + 50.
 	Project uiManager openToolsAttachedToMouseCursor ifTrue: [
 		window setProperty: #initialDrop toValue: true.
 		window hasDropShadow: false.


### PR DESCRIPTION
With this change, `SBEditor open` will no longer open a window that is smaller than the contained editor.

| Before | After |
| --- | --- |
![image](https://user-images.githubusercontent.com/38782922/130293686-380c8ce9-8316-4516-9d0f-b0b499c90025.png) | ![image](https://user-images.githubusercontent.com/38782922/130293784-ed39e184-07b9-4a9d-ad13-e6bfba721ec8.png) |