### PR TITLE
Integrate SimulationStudio

### DIFF
--- a/packages/BaselineOfSandblocks/BaselineOfSandblocks.class.st
+++ b/packages/BaselineOfSandblocks/BaselineOfSandblocks.class.st
@@ -50,13 +50,17 @@ BaselineOfSandblocks >> baseline: spec [
 			baseline: 'RatPack' with: [spec repository: 'github://hpi-swa-teaching/RatPack:develop/packages'];
 			baseline: 'QoppaS' with: [spec repository: 'github://hpi-swa-lab/QoppaS/packages'];
 			baseline: 'Ohm' with: [spec repository: 'github://hpi-swa/Ohm-S:master/packages'];
+			baseline: 'SimulationStudio' with: [
+				spec
+					repository: 'github://LinqLover/SimulationStudio/packages';
+					loads: #('SimulationStudio-Base' 'SimulationStudio-Sandbox')];
 			package: 'SVG-Morphic' with: [spec repository: 'http://www.squeaksource.com/SVGMorph'];
 			package: 'PoppyPrint-Core' with: [spec repository: 'github://tom95/poppy-print/packages'].
 
 		spec
 			package: 'Sandblocks-Core'
 				with: [spec requires: #('SVG-Morphic' 'Sandblocks-Morphs' 'Sandblocks-Layout' 'compatibility')];
-			package: 'Sandblocks-Smalltalk' with: [spec requires: #('Sandblocks-Core' 'PoppyPrint-Core')];
+			package: 'Sandblocks-Smalltalk' with: [spec requires: #('Sandblocks-Core' 'SimulationStudio' 'PoppyPrint-Core')];
 			package: 'Sandblocks-Explorer' with: [spec requires: #('Sandblocks-Core')];
 			package: 'Sandblocks-Watch' with: [spec requires: 'Sandblocks-Core'];
 			package: 'Sandblocks-Debugger' with: [spec requires: 'Sandblocks-Core'];
@@ -72,7 +76,7 @@ BaselineOfSandblocks >> baseline: spec [
 			package: 'Sandblocks-Compiler' with: [spec requires: 'Sandblocks-Core'];
 			package: 'Sandblocks-Babylonian' with: [spec requires: #('Sandblocks-Core' 'Sandblocks-Smalltalk')];
 			package: 'Sandblocks-Tutorial' with: [spec requires: 'default'];
-			package: 'Sandblocks-Representation' with: [spec requires: 'Sandblocks-Core'];
+			package: 'Sandblocks-Representation' with: [spec requires: #('Sandblocks-Core' 'SimulationStudio')];
 			package: 'Sandblocks-RatPack' with: [spec requires: #('default' 'RatPack')];
 			package: 'Sandblocks-ActiveExpression' with: [spec requires: #('default' 'ActiveExpressions')];
 			package: 'JumpingCubes' with: [spec requires: #('Sandblocks-ActiveExpression')].

--- a/packages/Sandblocks-Babylonian/SBTypeCollectSimulator.class.st
+++ b/packages/Sandblocks-Babylonian/SBTypeCollectSimulator.class.st
@@ -1,203 +1,60 @@
 Class {
 	#name : #SBTypeCollectSimulator,
-	#superclass : #InstructionClient,
+	#superclass : #SimulationContext,
+	#type : #variable,
 	#instVars : [
 		'methodMap',
-		'currentContext',
 		'topContext'
 	],
 	#category : #'Sandblocks-Babylonian'
 }
 
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> blockReturnConstant: value [
+{ #category : #'instruction decoding' }
+SBTypeCollectSimulator >> doPrimitive: primitiveIndex method: meth receiver: rcvr args: arguments [
 
-"	self reportTypeInfo: value at: currentContext."
-	^ currentContext blockReturnConstant: value
+	| result |
+	result := super doPrimitive: primitiveIndex method: meth receiver: rcvr args: arguments.
+	(self isDead not and: [self stackPtr > 0]) ifTrue: [self reportTypeInfo: self top at: self].
+	
+	"value:... block closure invocation"
+	((primitiveIndex between: 201 and: 222)
+	 and: [(self objectClass: receiver) includesBehavior: BlockClosure]) ifTrue: [
+		result arguments withIndexDo: [:argument :index |
+			self
+				reportTypeInfo: argument
+				at: (SBStCodeContext for: result)
+				findNode: [:methodMorph | (methodMorph blockBodyForPC: result method -> result pc)
+					ifNotNil: [:block | block bindings at: index]]]].
+	
+	^ result
 ]
 
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> blockReturnTop [
+{ #category : #'initialize-release' }
+SBTypeCollectSimulator >> initializeFrom: anotherContext [
 
-"	self reportTypeInfo: currentContext top at: currentContext."
-	^ currentContext blockReturnTop
+	super initializeFrom: anotherContext.
+	methodMap := anotherContext methodMap.
 ]
 
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> callPrimitive: pimIndex [
-	"SqueakV3PlusClosures:	239 11101111	iiiiiiii   jjjjjjjj  Call Primitive #iiiiiiii + (jjjjjjjj * 256)
-	 NewsqueakV4:				249 11111001	iiiiiiii   jjjjjjjj  Call Primitive #iiiiiiii + (jjjjjjjj * 256)
-	 SistaV1:					248 11111000 iiiiiiii mjjjjjjj  Call Primitive #iiiiiiii + (jjjjjjj * 256)
-									m=1 means inlined primitive, no hard return after execution."
-	^ currentContext callPrimitive: pimIndex
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> directedSuperSend: selector numArgs: numArgs [
-	"Send Message Above Specific Class With Selector, selector, bytecode.
-	 Start the lookup above the class that is the value of the association on
-	 top of stack. The arguments  of the message are found in the top numArgs
-	 stack locations beneath the association, and the receiver just below them."
-	^ currentContext directedSuperSend: selector numArgs: numArgs
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> doDup [
-	"Duplicate Top Of Stack bytecode."
-	^ currentContext doDup
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> doPop [
-	"Remove Top Of Stack bytecode."
-	^ currentContext doPop
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> jump: offset [
-	"Unconditional Jump bytecode."
-	^ currentContext jump: offset
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> jump: offset if: condition [ 
-	"Conditional Jump bytecode."
-	^ currentContext jump: offset if: condition
-]
-
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBTypeCollectSimulator >> maxTime [
 
 	^ 100 milliSeconds
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBTypeCollectSimulator >> methodMap [
 
 	^ methodMap
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBTypeCollectSimulator >> methodMap: aDictionary [
 
 	methodMap := aDictionary
 ]
 
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> methodReturnConstant: value [ 
-
-	self reportTypeInfo: value at: currentContext methodReturnContext sender.
-	^ currentContext methodReturnConstant: value
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> methodReturnReceiver [
-
-	self reportTypeInfo: currentContext receiver at: currentContext methodReturnContext sender.
-	^ currentContext methodReturnReceiver
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> methodReturnTop [
-
-	self reportTypeInfo: currentContext top at: currentContext methodReturnContext sender.
-	^ currentContext methodReturnTop
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> popIntoLiteralVariable: anAssociation [ 
-	"Remove Top Of Stack And Store Into Literal Variable bytecode."
-	^ currentContext popIntoLiteralVariable: anAssociation
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> popIntoReceiverVariable: offset [
-	"Remove Top Of Stack And Store Into Instance Variable bytecode."
-	^ currentContext popIntoReceiverVariable: offset
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
-	"Remove Top Of Stack And Store Into Offset of Temp Vector bytecode."
-	^ currentContext popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> popIntoTemporaryVariable: offset [ 
-	"Remove Top Of Stack And Store Into Temporary Variable bytecode."
-	^ currentContext popIntoTemporaryVariable: offset
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> pushActiveContext [
-	"Push Active Context On Top Of Its Own Stack bytecode."
-	^ currentContext pushActiveContext
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> pushClosureCopyNumCopiedValues: numCopied numArgs: numArgs blockSize: blockSize [
-	"Push Closure bytecode."
-	^ currentContext pushClosureCopyNumCopiedValues: numCopied numArgs: numArgs blockSize: blockSize
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> pushConsArrayWithElements: numElements [
-	"Push Cons Array of size numElements popping numElements items from the stack into the array bytecode."
-	^ currentContext pushConsArrayWithElements: numElements
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> pushConstant: value [
-	"Push Constant, value, on Top Of Stack bytecode."
-	^ currentContext pushConstant: value
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> pushFullClosure: aCompiledBlock numCopied: numCopied [
-	"Push Full Closure bytecode."
-	^ currentContext pushFullClosure: aCompiledBlock numCopied: numCopied
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> pushLiteralVariable: anAssociation [
-	"Push Contents Of anAssociation On Top Of Stack bytecode."
-	^ currentContext pushLiteralVariable: anAssociation
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> pushNewArrayOfSize: numElements [ 
-	"Push New Array of size numElements bytecode."
-	^ currentContext pushNewArrayOfSize: numElements
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> pushReceiver [
-	"Push Active Context's Receiver on Top Of Stack bytecode."
-	^ currentContext pushReceiver
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> pushReceiverVariable: offset [
-	"Push Contents Of the Receiver's Instance Variable Whose Index 
-	is the argument, offset, On Top Of Stack bytecode."
-	^ currentContext pushReceiverVariable: offset
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> pushRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
-	"Push Contents at Offset in Temp Vector bytecode."
-	^ currentContext pushRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> pushTemporaryVariable: offset [
-
-	"Transcript showln: {currentContext tempAt: offset + 1. currentContext endPC}."
-	
-	^ currentContext pushTemporaryVariable: offset
-]
-
-{ #category : #'as yet unclassified' }
+{ #category : #private }
 SBTypeCollectSimulator >> reportTypeInfo: anObject at: aContext [
 
 	"location := (SBCodeContext for: aContext) pc: (aContext previousPc)."
@@ -205,106 +62,31 @@ SBTypeCollectSimulator >> reportTypeInfo: anObject at: aContext [
 	methodMap at: aContext method sandblocksFastHash ifPresent: [:method | method cacheType: anObject class for: (method blockForPC: aContext previousPc)]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #private }
 SBTypeCollectSimulator >> reportTypeInfo: anObject at: aContext findNode: aBlock [
 
 	aContext method ifNotNil: [:m |
 		methodMap at: m sandblocksFastHash ifPresent: [:method | method cacheType: anObject class for: (aBlock value: method)]]
 ]
 
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> send: selector super: supered numArgs: numArgs [
+{ #category : #'instruction decoding' }
+SBTypeCollectSimulator >> return: value from: aSender [
 
-	| lookupClass |
-	lookupClass := supered
-		ifTrue: [currentContext method methodClassAssociation value superclass]
-		ifFalse: [currentContext objectClass: (currentContext at: currentContext stackPtr - numArgs)].
-	
+	aSender == aSender home ifTrue: ["method return"
+		self reportTypeInfo: value at: self methodReturnContext sender].
+	^ super return: value from: aSender
+]
+
+{ #category : #'instruction decoding' }
+SBTypeCollectSimulator >> send: selector to: rcvr with: arguments lookupIn: lookupClass [
+
 	(lookupClass lookupSelector: selector) ifNotNil: [:method |
-		" report argument types "
-		(currentContext stackPtr - numArgs + 1 to: currentContext stackPtr) withIndexDo: [:stackIndex :index |
+		arguments withIndexDo: [:argument :index |
 			SBStCodeContext class: lookupClass selector: selector ifValid: [:location |
 				self
-					reportTypeInfo: (currentContext at: stackIndex)
+					reportTypeInfo: argument
 					at: location
-					findNode: [:methodMorph | methodMorph arguments at: index]]].
-		
-		" report primitives "
-		method primitive > 0 ifTrue: [ | ret |
-			" perform:withArguments "
-			method primitive = 84 ifTrue: [ | actualSelector actualReceiver actualClass actualMethod |
-				actualReceiver := currentContext at: currentContext stackPtr - 2.
-				actualSelector := currentContext at: currentContext stackPtr - 1.
-				actualMethod := (currentContext objectClass: actualReceiver) lookupSelector: actualSelector.
-				actualMethod ifNil: [^ currentContext send: selector super: supered numArgs: numArgs].
-				
-				actualClass := actualMethod methodClass.
-				(currentContext at: currentContext stackPtr) withIndexDo: [:argument :index |
-					self
-						reportTypeInfo: argument
-						at: (SBStCodeContext class: actualClass selector: actualSelector)
-						findNode: [:methodMorph | methodMorph arguments at: index]].].
-			self flag: #todo. " other perform: variants "
-			
-			ret := currentContext send: selector super: supered numArgs: numArgs.
-			(currentContext isDead not and: [currentContext stackPtr > 0]) ifTrue: [self reportTypeInfo: currentContext top at: currentContext].
-			
-			" value:... block closure invocation "
-			((method primitive between: 201 and: 209) or: [method primitive between: 221 and: 222]) ifTrue: [
-				ret arguments withIndexDo: [:argument :index |
-					self
-						reportTypeInfo: argument
-						at: (SBStCodeContext for: ret)
-						findNode: [:methodMorph | (methodMorph blockBodyForPC: ret method -> ret pc) ifNotNil: [:block | block bindings at: index]]]].
-			
-			^ ret]].
+					findNode: [:methodMorph | methodMorph arguments at: index]]]].
 	
-	^ currentContext send: (selector = #halt ifTrue: [#yourself] ifFalse: [selector]) super: supered numArgs: numArgs
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> simulate: aBlock [
-
-	| simulationContext startTime |
-	aBlock hasMethodReturn ifTrue: [
-		self error: 'simulation of blocks with ^ can run loose'].
-	startTime := DateAndTime now.
-	simulationContext := thisContext.
-	currentContext := (topContext := aBlock asContext).
-	currentContext pushArgs: Array new from: simulationContext.
-	[currentContext == simulationContext] whileFalse: [
-		currentContext := currentContext interpretNextInstructionFor: self.
-		(DateAndTime now - startTime) > self maxTime ifTrue: [^ nil]].
-	^ simulationContext pop
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> storeIntoLiteralVariable: anAssociation [ 
-	"Store Top Of Stack Into Literal Variable Of Method bytecode."
-	^ currentContext storeIntoLiteralVariable: anAssociation
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> storeIntoReceiverVariable: offset [ 
-	"Store Top Of Stack Into Instance Variable Of Method bytecode."
-	^ currentContext storeIntoReceiverVariable: offset
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> storeIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
-	"Store Top Of Stack And Store Into Offset of Temp Vector bytecode."
-	^ currentContext storeIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> storeIntoTemporaryVariable: offset [ 
-	"Store Top Of Stack Into Temporary Variable Of Method bytecode."
-	^ currentContext storeIntoTemporaryVariable: offset
-]
-
-{ #category : #'as yet unclassified' }
-SBTypeCollectSimulator >> trapIfNotInstanceOf: behaviorOrArrayOfBehavior [
-	"If the top of stack is not an instance of either the argument, or, if the argument is an Array,
-	  any of the elements of the argument, send the class trap message to the current context."
-	^ currentContext trapIfNotInstanceOf: behaviorOrArrayOfBehavior
+	^ super send: selector to: rcvr with: arguments lookupIn: lookupClass
 ]

--- a/packages/Sandblocks-Core/SBReachabilitySimulatorTest.class.st
+++ b/packages/Sandblocks-Core/SBReachabilitySimulatorTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Sandblocks-Core-Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBReachabilitySimulatorTest >> exampleColorPolicy [
 
 	| a |
@@ -12,7 +12,7 @@ SBReachabilitySimulatorTest >> exampleColorPolicy [
 	#(21) do: [:num | 5 squared]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBReachabilitySimulatorTest >> exampleMethod [
 
 	| a |
@@ -21,7 +21,7 @@ SBReachabilitySimulatorTest >> exampleMethod [
 	a := 5 squared
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBReachabilitySimulatorTest >> testColorPolicy [
 
 	| editor method nestedSend compiledMethod |
@@ -34,7 +34,7 @@ SBReachabilitySimulatorTest >> testColorPolicy [
 	self assert: (editor colorPolicy wasReached: nestedSend)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBReachabilitySimulatorTest >> testReachability [
 
 	| policy m |
@@ -44,7 +44,7 @@ SBReachabilitySimulatorTest >> testReachability [
 	policy := SBReachabilityColorPolicy new.
 	SBStReachabilitySimulator new
 		store: policy;
-		simulate: [self exampleMethod].
+		runSimulated: [self exampleMethod].
 	
 	self assert: (policy reached: 101 in: m) description: 'Loop starter'.
 	self assert: (policy reached: (m literalAt: 2) -> 35 in: m) description: 'Send in loop'.

--- a/packages/Sandblocks-Representation/SBExtractFieldRepresentation.class.st
+++ b/packages/Sandblocks-Representation/SBExtractFieldRepresentation.class.st
@@ -47,7 +47,7 @@ SBExtractFieldRepresentation >> name: aSymbol [
 { #category : #'as yet unclassified' }
 SBExtractFieldRepresentation >> newFor: anObject [
 
-	^ SBStSandboxSimulator new simulate: [anObject perform: name]
+	^ Sandbox evaluate: [anObject perform: name]
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Smalltalk/SBExample.class.st
+++ b/packages/Sandblocks-Smalltalk/SBExample.class.st
@@ -400,7 +400,7 @@ SBExample >> showReachability [
 	self evaluateIn: [:exec |
 		SBStReachabilitySimulator new
 			store: policy;
-			simulate: exec].
+			runSimulated: exec].
 	self sandblockEditor colorPolicy: policy
 ]
 

--- a/packages/Sandblocks-Smalltalk/SBExample.class.st
+++ b/packages/Sandblocks-Smalltalk/SBExample.class.st
@@ -132,7 +132,7 @@ SBExample >> collectTypeInfo [
 	
 	SBTypeCollectSimulator new
 		methodMap: self currentMethodMap;
-		simulate: [[receiver perform: selector withArguments: arguments] on: Error do: []]
+		runSimulated: [[receiver perform: selector withArguments: arguments] on: Error do: []]
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Smalltalk/SBStASTNode.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStASTNode.class.st
@@ -110,7 +110,7 @@ SBStASTNode >> grammarHandler [
 { #category : #accessing }
 SBStASTNode >> guessClassExpensive [
 
-	^ self guessedClass ifNil: [[(SBStSandboxSimulator new simulate: [self evaluate]) ifNotNil: #class] on: Error do: [nil]]
+	^ self guessedClass ifNil: [Sandbox evaluate: [self evaluate class] ifFailed: [nil]]
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Smalltalk/SBStReachabilitySimulator.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStReachabilitySimulator.class.st
@@ -1,89 +1,40 @@
 Class {
 	#name : #SBStReachabilitySimulator,
-	#superclass : #SBStSimulator,
+	#superclass : #SimulationContext,
+	#type : #variable,
 	#instVars : [
 		'store'
 	],
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
-SBStReachabilitySimulator >> jump: offset if: condition [ 
-	store report: currentContext method pc: currentContext previousPc.
-	^ super jump: offset if: condition
+{ #category : #'initialize-release' }
+SBStReachabilitySimulator >> initializeFrom: anotherContext [
+
+	super initializeFrom: anotherContext.
+	store := anotherContext store.
 ]
 
-{ #category : #'as yet unclassified' }
-SBStReachabilitySimulator >> methodReturnConstant: value [ 
+{ #category : #private }
+SBStReachabilitySimulator >> report [
 
-	store report: currentContext method pc: currentContext previousPc.
-	^ super methodReturnConstant: value
+	store report: self method pc: self pc.
 ]
 
-{ #category : #'as yet unclassified' }
-SBStReachabilitySimulator >> methodReturnReceiver [
+{ #category : #'system simulation' }
+SBStReachabilitySimulator >> step [
 
-	store report: currentContext method pc: currentContext previousPc.
-	^ super methodReturnReceiver
+	self report.
+	^ super step
 ]
 
-{ #category : #'as yet unclassified' }
-SBStReachabilitySimulator >> methodReturnTop [
+{ #category : #accessing }
+SBStReachabilitySimulator >> store [
 
-	store report: currentContext method pc: currentContext previousPc.
-	^ super methodReturnTop
+	^ store
 ]
 
-{ #category : #'as yet unclassified' }
-SBStReachabilitySimulator >> popIntoLiteralVariable: offset [ 
-
-	store report: currentContext method pc: currentContext previousPc.
-	^ super popIntoLiteralVariable: offset
-]
-
-{ #category : #'as yet unclassified' }
-SBStReachabilitySimulator >> popIntoReceiverVariable: offset [ 
-
-	store report: currentContext method pc: currentContext previousPc.
-	^ super popIntoReceiverVariable: offset
-]
-
-{ #category : #'as yet unclassified' }
-SBStReachabilitySimulator >> popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
-
-	store report: currentContext method pc: currentContext previousPc.
-	^ super popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex
-]
-
-{ #category : #'as yet unclassified' }
-SBStReachabilitySimulator >> popIntoTemporaryVariable: offset [ 
-
-	store report: currentContext method pc: currentContext previousPc.
-	^ super popIntoTemporaryVariable: offset
-]
-
-{ #category : #'as yet unclassified' }
-SBStReachabilitySimulator >> pushClosureCopyNumCopiedValues: numCopied numArgs: numArgs blockSize: blockSize [
-
-	store report: currentContext method pc: currentContext previousPc.
-	^ super pushClosureCopyNumCopiedValues: numCopied numArgs: numArgs blockSize: blockSize
-]
-
-{ #category : #'as yet unclassified' }
-SBStReachabilitySimulator >> pushFullClosure: aCompiledBlock numCopied: numCopied [
-
-	store report: currentContext method pc: currentContext previousPc.
-	^ super pushFullClosure: aCompiledBlock numCopied: numCopied
-]
-
-{ #category : #'as yet unclassified' }
-SBStReachabilitySimulator >> send: selector super: supered numArgs: numArgs [
-
-	store report: currentContext method pc: currentContext previousPc.
-	^ super send: selector super: supered numArgs: numArgs
-]
-
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBStReachabilitySimulator >> store: aColorPolicy [
 
 	store := aColorPolicy


### PR DESCRIPTION
This PR switches the existing simulation features of Sandblocks to [SimulationStudio](https://github.com/LinqLover/SimulationStudio). Concretely, this affects the following classes:

- `SBStSandboxSimulator`: Switched to SimulationStudio's `Sandbox`.
- `SBStReachabilitySimulator`: Switched from `SBStSimulator` to SimulationStudio's `SimulationContext`. Refined reachability detection to match every single PC.
- `SBTypeCollectSimulator:`: Switched from `InstructionClient` to SimulationStudio's `SimulationContext`.
- The baseline is updated accordingly.

Open todos:

- [ ] Migrate `SBStTracingSimulator` too? I would be willing to do so, but without any entry point or test, I don't dare. We can also leave this class as-is if this is not important.
- [ ] Delete the old simulator classes? I will not do this without your explicit request. :-)

---

<details>
<summary><b>Why SimulationStudio?</b> (may contain traces of self-advertising 👀)</summary>

- SimulationStudio reuses and makes extensible the original meta-interpreter of Squeak. As a consequence, no reinvention of the wheel (as it is done in `InstructionClient`) is required, deduplication is avoided, and code will not come out of sync if the execution semantics of Squeak change (i.e., when a new primitive is introduced). All `thisContext` facilities that are required for proper meta-programming tasks such as exception handling are available to the simulated code as usually.

- SimulationStudio's sandbox enforces fewer limitations while simulating the code. If any side effect is detected, the simulation does not stop, but the side effect is simulated in a separate object space, visible only to the simulated stack frames. Most VM primitives have been annotated manually to support a maximum number of side-effect-free VM operations. Even interaction with the caller stack is safely possible, for instance:
   ```smalltalk
   [Sandbox evaluate: [self inform: #foo]] valueSuppressingAllMessages.
   ```
   At the same time, no outbreak is known yet. If you can find any, please keep them coming! :-)

- SimulationStudio offers better tooling; for instance, you can debug the simulated code in a debugger like this:
   ```smalltalk
   SBStReachabilitySimulator newFrom: [SBReachabilitySimulatorTest new exampleMethod] asContext)
   	store: SBReachabilityColorPolicy new;
   	debug.
   ```

For even more advertising, check out my way too long announcement email here: [[ANN] SimulationStudio and sandboxed execution for Squeak](http://forum.world.st/ANN-SimulationStudio-and-sandboxed-execution-for-Squeak-td5127804.html). ;-)
</details>