### PR TITLE
Fix type-guessing for `ProtoObject`s

### DIFF
--- a/packages/Sandblocks-Smalltalk/SBStASTNode.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStASTNode.class.st
@@ -115,7 +115,12 @@ SBStASTNode >> guessClassExpensive [
 			[
 				(sandboxClass new
 					stepLimit: 100000;
-					evaluate: [self evaluate] ifFailed: [nil]) ifNotNil: #class]
+					evaluate: [| result |
+						result := self evaluate.
+						[result class]
+							on: MessageNotUnderstood "might be ProtoObject"
+							do: [thisContext objectClass: result]]
+						ifFailed: [nil])]
 				on: SandboxError
 				do: [:err | nil]]]
 ]


### PR DESCRIPTION
If the result of the speculative evaluation does not understand the non-inlined message `#class`, use the mirror primitive instead. See https://github.com/LinqLover/SimulationStudio/issues/33.

Happens for example if you try to guess the class of `ProtoObject new`.