### PR TITLE
Add preference getter for adding Sandblocks to `CodeHolder`s

### DIFF
--- a/packages/Sandblocks-Core/CodeHolder.extension.st
+++ b/packages/Sandblocks-Core/CodeHolder.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #CodeHolder }
 
 { #category : #'*Sandblocks-Core' }
+CodeHolder class >> addSandblocksDefault [
+	<preference: 'Integrate Sandblocks into browsers' category: 'Sandblocks' description: 'If turned on, Smalltalk code in all standard tools such as browsers, message traces, etc. will be displayed as sandblocks. Reopen all tools to see an effect after toggling this preference.' type: #Boolean>
+
+	^ ContentsSymbolQuints first first = #blockEditor
+]
+
+{ #category : #'*Sandblocks-Core' }
 CodeHolder class >> addSandblocksDefault: aBoolean [
 
 	| quint |
@@ -99,5 +106,5 @@ CodeHolder >> toggleBlockEditor [
 { #category : #'*Sandblocks-Core' }
 CodeHolder class >> toggleSandblocksDefault [
 
-	self addSandblocksDefault: ContentsSymbolQuints first first ~= #blockEditor
+	self addSandblocksDefault: self addSandblocksDefault not
 ]


### PR DESCRIPTION
Just for convenience.

![image](https://user-images.githubusercontent.com/38782922/144716751-758f7b8b-9578-480e-9fa9-a2df2082477f.png)
