### PR TITLE
st: add binding fix actions for creating classvar/new class

### DIFF
--- a/packages/Sandblocks-Core/SBCommand.class.st
+++ b/packages/Sandblocks-Core/SBCommand.class.st
@@ -37,13 +37,13 @@ SBCommand class >> newOrEditFor: anArtefactOrNil [
 		yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBCommand >> affectedArtefacts [
 
 	^ self artefact ifNotNil: [{self artefact}] ifNil: [#()]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #apply }
 SBCommand >> applyPositionTo: aMorphOrCollection in: anOwner [
 
 	self position ifNil: [^ self].
@@ -59,13 +59,13 @@ SBCommand >> applyPositionTo: aMorphOrCollection in: anOwner [
 					ifAbsent: []]]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBCommand >> artefact [
 
 	^ artefact
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBCommand >> artefact: anObject [
 
 	artefact := anObject
@@ -78,7 +78,7 @@ SBCommand >> artefactFrom: aMorph [
 		self artefact: aMorph containingSandblock containingArtefact]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBCommand >> continueAfterInsert: aCharacter [
 	" mark that if this command has been used as an insertion point, the input should be forward to the new block "
 
@@ -91,7 +91,7 @@ SBCommand >> do [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'initialize-release' }
 SBCommand >> initialize [
 
 	super initialize.
@@ -100,38 +100,38 @@ SBCommand >> initialize [
 	wasEdit := true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBCommand >> position [
 	" if set, the position where new morphs should be placed "
 
 	^ position
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBCommand >> position: aPoint [
 
 	position := aPoint
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #apply }
 SBCommand >> postDo [
 
 	" you may do any action here after the 'do' has completed that does not affect any state that should be undo-able, e.g. you may move focus to a specific part here "
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #apply }
 SBCommand >> preDo [
 
 	artefact ifNil: [self artefactFrom: self setArtefactFrom]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBCommand >> previousSelection [
 
 	^ previousSelection
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBCommand >> previousSelection: aBlock [
 
 	previousSelection := aBlock
@@ -151,25 +151,25 @@ SBCommand >> selectAfter: aBlock [
 	selectAfter := aBlock
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBCommand >> setArtefactFrom [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBCommand >> shouldMergeWithNext [
 
 	^ shouldMergeWithNext
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBCommand >> shouldMergeWithNext: aBoolean [
 
 	shouldMergeWithNext := aBoolean
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBCommand >> title [
 
 	^ nil
@@ -181,7 +181,7 @@ SBCommand >> undo [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBCommand >> valid [
 
 	^ true

--- a/packages/Sandblocks-Smalltalk/SBStBinding.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStBinding.class.st
@@ -46,30 +46,37 @@ SBStBinding >> contentsChanged [
 { #category : #'as yet unclassified' }
 SBStBinding >> fixActions [
 
-	^ self validBinding ifTrue: [#()] ifFalse: [
-		{
-			(self block containingBlock ifNotNil: [:b | b isMethodBody not] ifNil: [false])
-				ifTrue: [
-					SBCodeAction
+	^ self validBinding ifTrue: [#()] ifFalse: [Array streamContents: [:stream |
+		self contents first isLowercase ifTrue: [
+			self block containingBlock ifNotNil: [:b |
+				b isMethodBody ifFalse: [
+					stream nextPut: (SBCodeAction
 						labeled: 'Declare block-local'
 						for: self block
-						do: [:node | node containingBlock declareTemporaryVariable: node contents]]
-				ifFalse: [nil].
-			SBCodeAction
+						do: [:node | node containingBlock declareTemporaryVariable: node contents])]].
+			stream nextPut: (SBCodeAction
 				labeled: 'Declare method temporary'
 				for: self block
-				do: [:node | node containingArtefact body declareTemporaryVariable: node contents].
-			SBCodeAction
+				do: [:node | node containingArtefact body declareTemporaryVariable: node contents]).
+			stream nextPut: (SBCodeAction
 				labeled: 'Declare instance variable'
 				for: self block
-				do: [:node | self declareInstanceVariable].
+				do: [:node | self declareInstanceVariable]).
 			self block containingArtefact isMethod
 				ifTrue: [
-					SBCodeAction labeled: 'Add method argument' for: self block do: [:node |
+					stream nextPut: (SBCodeAction labeled: 'Add method argument' for: self block do: [:node |
 						node containingArtefact signature
 							addArgument: (self argNameToType: node contents)
-							block: node veryDeepCopy]]
-				ifFalse: [nil]} select: #notNil]
+							block: node veryDeepCopy])]].
+		self contents first isUppercase ifTrue: [
+			stream nextPut: (SBCodeAction
+				labeled: 'Declare class variable'
+				for: self block
+				do: [:node | self declareClassVariable]).
+			stream nextPut: (SBCodeAction
+				labeled: 'Create class'
+				for: self block
+				do: [:node | self createClass])]]]
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Smalltalk/SBStClass.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStClass.class.st
@@ -164,7 +164,7 @@ SBStClass >> deleteClass [
 		self delete].
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'artefact protocol' }
 SBStClass >> ensureExpanded [
 ]
 
@@ -189,7 +189,7 @@ SBStClass >> inheritsFrom: aClass [
 	^ self superclass = aClass or: [self superclass inheritsFrom: aClass]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 SBStClass >> initialize [
 
 	super initialize.
@@ -248,55 +248,61 @@ SBStClass >> instanceVariables: aCollection [
 			addMorphBack: (SBStName instanceVariable: name class: self relatedClass)]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStClass >> isArtefact [
 
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStClass >> isClassContainer [
 
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStClass >> isEditor [
 
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'*Sandblocks-Smalltalk' }
+SBStClass >> isSmalltalk [
+
+	^ true
+]
+
+{ #category : #testing }
 SBStClass >> isTopLevel [
 
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStClass >> name [
 
 	^ self shownClassName
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'object interface' }
 SBStClass >> object [
 
 	^ self relatedClass ifNil: [ UndefinedObject ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'colors and color policies' }
 SBStClass >> preferredColor [
 
 	^ SBStASTNode preferredColor
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStClass >> preventOcclusion [
 
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #printing }
 SBStClass >> printOn: aStream [
 
 	aStream nextPutAll: self shownClassName
@@ -312,7 +318,7 @@ SBStClass >> references [
 			(block object = self object and: [block ~= self]) ifTrue: [stream nextPut: block]]]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'artefact protocol' }
 SBStClass >> relatedClass [
 
 	^ class ifNil: [UndefinedObject]
@@ -336,7 +342,7 @@ SBStClass >> renameClass [
 	
 ]
 
-{ #category : #nil }
+{ #category : #saving }
 SBStClass >> saveString [
 
 	^ String streamContents: [:stream |
@@ -350,7 +356,7 @@ SBStClass >> saveString [
 		]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'artefact protocol' }
 SBStClass >> saveTryFixing: aBoolean quick: aQuickBoolean [
 
 	| oldClass environment newClassName oldName references blockReferences |
@@ -433,13 +439,13 @@ SBStClass >> superclass [
 	^ Smalltalk at: self superClassName asSymbol
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBStClass >> textContents [
 
 	^ self shownClass name
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'artefact protocol' }
 SBStClass >> wantsInteractiveErrorCorrection [
 
 	^ false

--- a/packages/Sandblocks-Smalltalk/SBStClass.extension.st
+++ b/packages/Sandblocks-Smalltalk/SBStClass.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SBStClass }
+
+{ #category : #'*Sandblocks-Smalltalk' }
+SBStClass >> isSmalltalk [
+
+	^ true
+]

--- a/packages/Sandblocks-Smalltalk/SBStCreateClassCommand.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStCreateClassCommand.class.st
@@ -1,0 +1,54 @@
+Class {
+	#name : #SBStCreateClassCommand,
+	#superclass : #SBCommand,
+	#instVars : [
+		'name',
+		'editor',
+		'source',
+		'class'
+	],
+	#category : #'Sandblocks-Smalltalk'
+}
+
+{ #category : #apply }
+SBStCreateClassCommand >> do [
+
+	class := SBStClass new
+		className: name;
+		category: ((self artefact ifNotNil: [:container | container relatedClass])
+			ifNotNil: #category
+			ifNil: ['UserObjects']).
+	editor createArtefactInView: class.
+	^ source
+]
+
+{ #category : #accessing }
+SBStCreateClassCommand >> editor: anEditor [
+
+	editor := anEditor
+]
+
+{ #category : #accessing }
+SBStCreateClassCommand >> name: aString [
+
+	name := aString
+]
+
+{ #category : #accessing }
+SBStCreateClassCommand >> setArtefactFrom [
+
+	^ nil
+]
+
+{ #category : #accessing }
+SBStCreateClassCommand >> source: aBlock [
+
+	source := aBlock
+]
+
+{ #category : #apply }
+SBStCreateClassCommand >> undo [
+
+	class deleteClass.
+	^ source
+]

--- a/packages/Sandblocks-Smalltalk/SBStDeclareBehaviorVarCommand.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStDeclareBehaviorVarCommand.class.st
@@ -1,0 +1,78 @@
+Class {
+	#name : #SBStDeclareBehaviorVarCommand,
+	#superclass : #SBCommand,
+	#instVars : [
+		'class',
+		'name',
+		'editor',
+		'newBindings',
+		'source'
+	],
+	#category : #'Sandblocks-Smalltalk'
+}
+
+{ #category : #apply }
+SBStDeclareBehaviorVarCommand >> basicDo [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #apply }
+SBStDeclareBehaviorVarCommand >> basicUndo [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+SBStDeclareBehaviorVarCommand >> class: aClass [
+
+	class := aClass
+]
+
+{ #category : #apply }
+SBStDeclareBehaviorVarCommand >> do [
+
+	self basicDo.
+	newBindings := (source sandblockEditor
+		allBlocksFor: class
+		withInterfaces: SBInterfaces editor) collect: [:stClass | | binding variables |
+		binding := SBStName contents: name.
+		variables := self variablesInClass: stClass.
+		variables submorphs
+			detect: [:m | m contents = name]
+			ifNone: [variables addMorphBack: binding].
+		binding].
+	^ source
+]
+
+{ #category : #accessing }
+SBStDeclareBehaviorVarCommand >> name: aString [
+
+	name := aString
+]
+
+{ #category : #accessing }
+SBStDeclareBehaviorVarCommand >> setArtefactFrom [
+
+	^ nil
+]
+
+{ #category : #accessing }
+SBStDeclareBehaviorVarCommand >> source: aBlock [
+
+	source := aBlock
+]
+
+{ #category : #apply }
+SBStDeclareBehaviorVarCommand >> undo [
+
+	self basicUndo.
+	newBindings do: #delete.
+	^ source
+]
+
+{ #category : #private }
+SBStDeclareBehaviorVarCommand >> variablesInClass: anStClass [
+
+	^ self subclassResponsibility
+]

--- a/packages/Sandblocks-Smalltalk/SBStDeclareClassVarCommand.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStDeclareClassVarCommand.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : #SBStDeclareClassVarCommand,
+	#superclass : #SBStDeclareBehaviorVarCommand,
+	#category : #'Sandblocks-Smalltalk'
+}
+
+{ #category : #apply }
+SBStDeclareClassVarCommand >> basicDo [
+
+	^ class addClassVarName: name
+]
+
+{ #category : #apply }
+SBStDeclareClassVarCommand >> basicUndo [
+
+	class removeClassVarName: name
+]
+
+{ #category : #private }
+SBStDeclareClassVarCommand >> variablesInClass: anStClass [
+
+	^ anStClass classVariables
+]

--- a/packages/Sandblocks-Smalltalk/SBStDeclareInstVarCommand.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStDeclareInstVarCommand.class.st
@@ -1,57 +1,23 @@
 Class {
 	#name : #SBStDeclareInstVarCommand,
-	#superclass : #SBCommand,
-	#instVars : [
-		'class',
-		'name',
-		'editor',
-		'newBindings',
-		'source'
-	],
+	#superclass : #SBStDeclareBehaviorVarCommand,
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
-SBStDeclareInstVarCommand >> class: aClass [
+{ #category : #apply }
+SBStDeclareInstVarCommand >> basicDo [
 
-	class := aClass
+	^ class addInstVarName: name
 ]
 
-{ #category : #'as yet unclassified' }
-SBStDeclareInstVarCommand >> do [
+{ #category : #apply }
+SBStDeclareInstVarCommand >> basicUndo [
 
-	class addInstVarName: name.
-	newBindings := (source sandblockEditor allBlocksFor: class withInterfaces: SBInterfaces editor) collect: [:class | | binding |
-		binding := SBStName contents: name.
-		class instanceVariables submorphs
-			detect: [:m | m contents = name]
-			ifNone: [class instanceVariables addMorphBack: binding].
-		binding].
-	^ source
+	class removeInstVarName: name
 ]
 
-{ #category : #'as yet unclassified' }
-SBStDeclareInstVarCommand >> name: aString [
+{ #category : #private }
+SBStDeclareInstVarCommand >> variablesInClass: anStClass [
 
-	name := aString
-]
-
-{ #category : #'as yet unclassified' }
-SBStDeclareInstVarCommand >> setArtefactFrom [
-
-	^ nil
-]
-
-{ #category : #'as yet unclassified' }
-SBStDeclareInstVarCommand >> source: aBlock [
-
-	source := aBlock
-]
-
-{ #category : #'as yet unclassified' }
-SBStDeclareInstVarCommand >> undo [
-
-	class removeInstVarName: name.
-	newBindings do: #delete.
-	^ source
+	^ anStClass instanceVariables
 ]

--- a/packages/Sandblocks-Smalltalk/SBStNameBehavior.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStNameBehavior.class.st
@@ -54,11 +54,35 @@ SBStNameBehavior >> contentsChanged [
 ]
 
 { #category : #'as yet unclassified' }
+SBStNameBehavior >> createClass [
+
+	<action>
+	<actionValidIf: #noValidBinding>
+
+	self block sandblockEditor do: (SBStCreateClassCommand new
+		name: self contents;
+		source: self block;
+		editor: self block sandblockEditor;
+		artefact: self block containingArtefact)
+]
+
+{ #category : #'as yet unclassified' }
 SBStNameBehavior >> declareBlockVariable [
 	<action>
 	<actionValidIf: #noValidBinding>
 	
 	self block containingBlock declareTemporaryVariable: self contents
+]
+
+{ #category : #'as yet unclassified' }
+SBStNameBehavior >> declareClassVariable [
+	<action>
+	<actionValidIf: #noValidBinding>
+
+	self block sandblockEditor do: (SBStDeclareClassVarCommand new
+		class: self block containingArtefact methodClass theNonMetaClass;
+		name: self contents;
+		source: self block)
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
Only suggest fixes that follow the camelCase/PascalCase convention for Smalltalk identifiers. Extract `SBStDeclareBehaviorVarCommand` from `SBStDeclareInstVarCommand` and inherit from it in new `SBStDeclareClassVarCommand`. Add `SBStCreateClassCommand`. Partial recategorizations in related classes.

---

![image](https://user-images.githubusercontent.com/38782922/148447873-cb20ec3f-311d-409d-8200-d087f47b0cd5.png)
![image](https://user-images.githubusercontent.com/38782922/148447899-34635349-b774-4aee-87d2-af332c7ac645.png)

---

![image](https://user-images.githubusercontent.com/38782922/148447973-228968a6-ad82-4497-ac84-14c90f2b34da.png)
![image](https://user-images.githubusercontent.com/38782922/148448000-cb957d71-3f46-4f37-8773-394bdd777b31.png)

---

![image](https://user-images.githubusercontent.com/38782922/148448201-8e41b0f9-47e5-4775-9887-076c404a3199.png)
![image](https://user-images.githubusercontent.com/38782922/148448228-8594bdb2-a52a-4438-80ac-56b8e5ac4714.png)

---

Undo works, too:

![image](https://user-images.githubusercontent.com/38782922/148448929-36467b9f-c5b7-4603-8c2f-d82907d6a347.png)

---

Also tested with `SBBrowserEditor`:

![image](https://user-images.githubusercontent.com/38782922/148448605-b777a48c-188a-4641-91d1-5ed0559e271d.png)

---

Remaining bugs (but rather not introduced by this patch):

- `SBGroup` is not automatically resized after inserting/removing a binding

Please do not hesitate to mention me in any follow-up commit that revises anything from this patch so that I can learn what to do better. :-)