### PR TITLE
Complements SUnit-ct.130 (Trunk)

### DIFF
--- a/packages/Sandblocks-Babylonian/SBStTestCase.class.st
+++ b/packages/Sandblocks-Babylonian/SBStTestCase.class.st
@@ -248,7 +248,7 @@ SBStTestCase >> runTest [
 			do: [:err |
 				self reportError: err.
 				err return: false]
-			on: TestResult error
+			on: TestResult exError
 			do: [:err |
 				self reportError: err.
 				err return: false]) ifTrue: [


### PR DESCRIPTION
`TestResult class >> #error` is deprecated now.